### PR TITLE
Add Support for LineSprinklersRedux

### DIFF
--- a/SprinklerActivation/Integrations/ILineSprinklersReduxAPI.cs
+++ b/SprinklerActivation/Integrations/ILineSprinklersReduxAPI.cs
@@ -1,0 +1,27 @@
+﻿using SObject = StardewValley.Object;
+
+namespace LineSprinklersRedux
+{
+    public interface ILineSprinklersReduxAPI
+    {
+        /// <summary>
+        ///   Plays the Sprinkler Animation for a given Sprinkler Object.
+        /// </summary>
+        /// <param name="sprinkler">The sprinkler Object for which to play animation</param>
+        /// <param name="delayBeforeAnimationStart">The delay in milliseconds before playing the sprinkler.</param>
+        void PlaySprinklerAnimation(SObject sprinkler, int delayBeforeAnimationStart);
+
+        /// <summary>
+        ///   Waters the tiles covered by the sprinkler passed as a parameter. This method does NOT
+        ///   play the animation. To play animation, see PlaySprinklerAnimation
+        /// </summary>
+        /// <param name="sprinkler">The sprinkler Object whose tiles should be watered.</param>
+        void ApplySprinkler(SObject sprinkler);
+
+        /// <summary>
+        ///  Returns true if the passed object is a LineSprinkler owned by this mod.
+        /// </summary>
+        /// <param name="sprinkler">The sprinkler to be checked.</param>
+        bool IsLineSprinkler(SObject sprinkler);
+    }
+}

--- a/SprinklerActivation/SprinklerActivation.cs
+++ b/SprinklerActivation/SprinklerActivation.cs
@@ -11,6 +11,8 @@ using StardewValley;
 using StardewValley.TerrainFeatures;
 using StardewValley.Tools;
 
+using LineSprinklersRedux;
+
 namespace SprinklerActivation
 {
     public class SprinklerActivation : Mod
@@ -19,7 +21,9 @@ namespace SprinklerActivation
         private object? BetterSprinklersApi = null;
         private object? PrismaticToolsApi = null;
         private object? SimpleSprinklerApi = null;
+        private ILineSprinklersReduxAPI LineSprinklersReduxApi = null;
         private bool LineSprinklersIsLoaded;
+        
         private Multiplayer? mp = null;
 
         enum animSize
@@ -63,7 +67,13 @@ namespace SprinklerActivation
                 SimpleSprinklerApi = Helper.ModRegistry.GetApi("tZed.SimpleSprinkler");
             }
 
+            if (Helper.ModRegistry.IsLoaded("rtrox.LineSprinklersRedux"))
+            {
+                LineSprinklersReduxApi = Helper.ModRegistry.GetApi<ILineSprinklersReduxAPI>("rtrox.LineSprinklersRedux");
+            }
+
             LineSprinklersIsLoaded = Helper.ModRegistry.IsLoaded("hootless.LineSprinklers");
+           
         }
 
         private void OnWorld_ObjectListChanged(object sender, ObjectListChangedEventArgs e)
@@ -108,6 +118,11 @@ namespace SprinklerActivation
                 if (LineSprinklersIsLoaded && sprinkler.Name.Contains("Line"))
                 {
                     ActivateLineSprinkler(sprinkler);
+                }
+                else if (LineSprinklersReduxApi != null && LineSprinklersReduxApi.IsLineSprinkler(sprinkler))
+                {
+                    LineSprinklersReduxApi.ApplySprinkler(sprinkler);
+                    LineSprinklersReduxApi.PlaySprinklerAnimation(sprinkler, Game1.random.Next(500));
                 }
                 else if (PrismaticToolsApi != null && sprinkler.Name.Contains("Prismatic"))
                 {


### PR DESCRIPTION
This PR adds support for [Line Sprinklers Redux](https://www.nexusmods.com/stardewvalley/mods/23895) ([GitHub](https://github.com/rtrox/LineSprinklersRedux)) leveraging it's public API. This mod is a 1.6 compatible ground-up rewrite of the long-deprecated Line Sprinklers mod by hootless.

**This change is backwards-compatible -**- if the user has an older version of Line Sprinklers Redux involved which does not support the public API, `GetApi()` will return null, and SprinklerActivation will just work as if the integration were never added.

**Testing**:
[GIF of functioning integration](https://r2.rtrox.io/2024-05-17%2002-33-30.gif)
![Test GIF](https://r2.rtrox.io/2024-05-17%2002-33-30.gif)